### PR TITLE
Update slimbot.js

### DIFF
--- a/src/slimbot.js
+++ b/src/slimbot.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('eventemitter3');
 const Telegram = require('./telegram');
 
@@ -49,6 +51,7 @@ class Slimbot extends Telegram(EventEmitter) {
       if (updates !== undefined) {
         this._processUpdates(updates);
       }
+      return null;
     })
     .catch(error => {
       if (callback) {


### PR DESCRIPTION
This addresses an issue where meteor throw's an error at run time where it's requiring 'use strict' to allow es6 syntax (e.g. let, const, etc). Also throws an error because of missing return in promise ".then" functions