### PR TITLE
Fix usage of getUpdates offset

### DIFF
--- a/spec/core/telebotSpec.js
+++ b/spec/core/telebotSpec.js
@@ -57,17 +57,22 @@ describe('Slimbot', () => {
       beforeEach(() => {
         updates = {
           result: [
-            { message: 'message' },
-            { edited_message: 'edited_message' },
-            { channel_post: 'channel_post' },
-            { edited_channel_post: 'edited_channel_post' },
-            { callback_query: 'callback_query' },
-            { inline_query: 'inline_query' },
-            { chosen_inline_result: 'chosen_inline_result' },
-            { shipping_query: 'shipping_query' },
-            { pre_checkout_query: 'pre_checkout_query' }
+            { update_id: 1000, message: 'message' },
+            { update_id: 1001, edited_message: 'edited_message' },
+            { update_id: 1002, channel_post: 'channel_post' },
+            { update_id: 1003, edited_channel_post: 'edited_channel_post' },
+            { update_id: 1004, callback_query: 'callback_query' },
+            { update_id: 1005, inline_query: 'inline_query' },
+            { update_id: 1006, chosen_inline_result: 'chosen_inline_result' },
+            { update_id: 1007, shipping_query: 'shipping_query' },
+            { update_id: 1008, pre_checkout_query: 'pre_checkout_query' }
           ]
         };
+      });
+
+      it('should take the id of last update increased by 1 as offset', () => {
+        slimbot._processUpdates(updates);
+        expect(slimbot._offset).toEqual(1009);
       });
 
       it('should emit "message" if update is of type "message"', () => {
@@ -184,11 +189,6 @@ describe('Slimbot', () => {
   // Slimbot API methods
 
   describe('startPolling', () => {
-    it('should increase offset by 1', () => {
-      slimbot.startPolling();
-      expect(0 < slimbot._offset).toEqual(true);
-    });
-
     it('should call slimbot._request', () => {
       spyOn(slimbot, '_request').and.returnValue(Bluebird.resolve());
       slimbot.startPolling();

--- a/src/slimbot.js
+++ b/src/slimbot.js
@@ -6,12 +6,12 @@ const Telegram = require('./telegram');
 class Slimbot extends Telegram(EventEmitter) {
   constructor(token) {
     super(token);
-    this._offset = 0;
+    this._offset = undefined;
   }
 
   _processUpdates(updates) {
     updates.result.forEach(update => {
-      this._offset = update.update_id;
+      this._offset = update.update_id + 1;
       let message = update.message;
       let editedMessage = update.edited_message;
       let channelPost = update.channel_post;
@@ -45,7 +45,6 @@ class Slimbot extends Telegram(EventEmitter) {
   }
 
   startPolling(callback) {
-    this._offset++;
     return super.getUpdates(this._offset)
     .then(updates => {
       if (updates !== undefined) {


### PR DESCRIPTION
Without this patch slimbot increments getUpdates offset every time getUpdates
is called. So the offset value is usually greater then the received updates id.
But the doc says that:

"Identifier of the first update to be returned. Must be greater by one than
the highest among the identifiers of previously received updates. By default,
updates starting with the earliest unconfirmed update are returned. An update
is considered confirmed as soon as getUpdates is called with an offset higher
than its update_id."

The current behaviour is not in conformance to the doc and seems to result in
losing updates from time to time.