### PR TITLE
Correction of the answerPreCheckoutQuery function. 

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1238,7 +1238,7 @@ const Telegram = EventEmitter => class extends EventEmitter {
       error_message: errorMessage
     };
 
-    return this._request('answerShippingQuery', params, callback);
+    return this._request('answerPreCheckoutQuery', params);
   }
 
   // Games


### PR DESCRIPTION
The function retuned the wrong callback.

Bug fixes:
return this._request ('answerShippingQuery', params, callback);
                                                        ^
ReferenceError: callback is not defined

Fix #50